### PR TITLE
uploadProgressBlock is not called when using STTwitterOS

### DIFF
--- a/STTwitter/STTwitterOS.m
+++ b/STTwitter/STTwitterOS.m
@@ -154,7 +154,7 @@
          baseURLString:(NSString *)baseURLString
             httpMethod:(NSInteger)httpMethod
             parameters:(NSDictionary *)params
-   uploadProgressBlock:(void(^)(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite))uploadProgressBlock // ignored
+   uploadProgressBlock:(void(^)(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite))uploadProgressBlock
        completionBlock:(void (^)(id request, NSDictionary *requestHeaders, NSDictionary *responseHeaders, id response))completionBlock
             errorBlock:(void (^)(id request, NSDictionary *requestHeaders, NSDictionary *responseHeaders, NSError *error))errorBlock {
     
@@ -163,7 +163,7 @@
                                                             httpMethod:httpMethod
                                                             parameters:params
                                                                account:self.account
-                                                   uploadProgressBlock:nil
+                                                   uploadProgressBlock:uploadProgressBlock
                                                        completionBlock:completionBlock
                                                             errorBlock:errorBlock];
     
@@ -176,7 +176,7 @@
          HTTPMethod:(NSString *)HTTPMethod
       baseURLString:(NSString *)baseURLString
          parameters:(NSDictionary *)params
-uploadProgressBlock:(void(^)(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite))uploadProgressBlock // ignored
+uploadProgressBlock:(void(^)(NSInteger bytesWritten, NSInteger totalBytesWritten, NSInteger totalBytesExpectedToWrite))uploadProgressBlock
 downloadProgressBlock:(void (^)(id request, id response))progressBlock // FIXME: how to handle progressBlock?
        successBlock:(void (^)(id request, NSDictionary *requestHeaders, NSDictionary *responseHeaders, id response))successBlock
          errorBlock:(void (^)(id request, NSDictionary *requestHeaders, NSDictionary *responseHeaders, NSError *error))errorBlock {


### PR DESCRIPTION
Hi,

I found this issue while using STTwitter with iOS and ACAcount.
The uploadProgressBlock I provided to `[STTwitterAPO postStatusUpdate: ...]` was not called.

STTwitterOS is ignoring it. I found a comment ("ignored") next to block which surprise me because it seems to be on purpose. I checked history and I couldn't find the reason.

I tried this fix and it works.

Thanks,
Ariel
