### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Drag and drop STTwitter directory into your project.
 Link your project with the following frameworks:
 
 - Accounts.framework
-- Twitter.framework
+- Social.framework
+- Twitter.framework (iOS only)
 - Security.framework (OS X only)
-- Social.framework (iOS only, weak)
 
 If you want to use CocoaPods, add the following two lines to your Podfile:
 


### PR DESCRIPTION
As of 10.8, what was Twitter.framework under OS X was apparently rolled into
Social.framework (http://stackoverflow.com/a/11697689). Twitter.framework is
absent from the 10.9 SDK, but present in iOS 7.1.
