### PR TITLE
Fix a retain cycle of STHTTPRequest objects in STTwitterOAuth.

### DIFF
--- a/STTwitter/STTwitterOAuth.m
+++ b/STTwitter/STTwitterOAuth.m
@@ -454,16 +454,17 @@
     
     NSMutableString *urlString = [NSMutableString stringWithFormat:@"%@/%@", baseURLString, resource];
     
-    __block STHTTPRequest *r = [STHTTPRequest twitterRequestWithURLString:urlString
+    __block __weak STHTTPRequest *wr = nil;
+    STHTTPRequest *r = [STHTTPRequest twitterRequestWithURLString:urlString
                                              stTwitterUploadProgressBlock:nil
                                            stTwitterDownloadProgressBlock:^(id json) {
-                                               if(downloadProgressBlock) downloadProgressBlock(r, json);
+                                               if(downloadProgressBlock) downloadProgressBlock(wr, json);
                                            } stTwitterSuccessBlock:^(NSDictionary *requestHeaders, NSDictionary *responseHeaders, id json) {
-                                               successBlock(r, requestHeaders, responseHeaders, json);
+                                               successBlock(wr, requestHeaders, responseHeaders, json);
                                            } stTwitterErrorBlock:^(NSDictionary *requestHeaders, NSDictionary *responseHeaders, NSError *error) {
-                                               errorBlock(r, requestHeaders, responseHeaders, error);
+                                               errorBlock(wr, requestHeaders, responseHeaders, error);
                                            }];
-    
+    wr = r;
     r.GETDictionary = params;
     
     [self signRequest:r];
@@ -523,16 +524,17 @@ downloadProgressBlock:(void(^)(id r, id json))downloadProgressBlock
     
     NSString *urlString = [NSString stringWithFormat:@"%@/%@", baseURLString, resource];
     
-    __block STHTTPRequest *r = [STHTTPRequest twitterRequestWithURLString:urlString
+    __block __weak STHTTPRequest *wr = nil;
+    STHTTPRequest *r = [STHTTPRequest twitterRequestWithURLString:urlString
                                              stTwitterUploadProgressBlock:uploadProgressBlock
                                            stTwitterDownloadProgressBlock:^(id json) {
-                                               if(downloadProgressBlock) downloadProgressBlock(r, json);
+                                               if(downloadProgressBlock) downloadProgressBlock(wr, json);
                                            } stTwitterSuccessBlock:^(NSDictionary *requestHeaders, NSDictionary *responseHeaders, id json) {
-                                               successBlock(r, requestHeaders, responseHeaders, json);
+                                               successBlock(wr, requestHeaders, responseHeaders, json);
                                            } stTwitterErrorBlock:^(NSDictionary *requestHeaders, NSDictionary *responseHeaders, NSError *error) {
-                                               errorBlock(r, requestHeaders, responseHeaders, error);
+                                               errorBlock(wr, requestHeaders, responseHeaders, error);
                                            }];
-    
+    wr = r;
     r.POSTDictionary = params;
     
 	NSString *postKey = [params valueForKey:kSTPOSTDataKey];


### PR DESCRIPTION
Under ARC (and not under MRR), variables declared __block are retained
when captured in a copied block. The solution is to another __block
__weak declared variable and use that within the blocks copied by the
STHTTPRequest.

This issue is particularly bad if you're posting images, as I was,
because the image data is retained by the STHTTPRequest. So every
image post you leak the whole image data.
