### PR TITLE
External clock singleton. Can be used to provide valid NTP timestamp to avoid 401: Unauthorized error when using OAuth with inaccurate system clock setup.

### DIFF
--- a/STTwitter/STTwitterClock.h
+++ b/STTwitter/STTwitterClock.h
@@ -1,0 +1,24 @@
+//
+//  STTwitterClock.h
+//  STTwitter
+//
+//  Created by Kirill Nepomnyaschiy on 25.12.14.
+//  Copyright (c) 2014 Nicolas Seriot. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol STTwitterTimeProvider <NSObject>
+-(NSTimeInterval)timestamp;
+@end
+
+@interface STTwitterClock : NSObject
+
+@property (strong, nonatomic) id <STTwitterTimeProvider> timeProvider;
+
+@property (nonatomic, readonly) NSTimeInterval timestamp;
+@property (nonatomic, readonly, getter=isAvailable) BOOL available;
+
++(instancetype)sharedInstance;
+
+@end

--- a/STTwitter/STTwitterClock.m
+++ b/STTwitter/STTwitterClock.m
@@ -1,0 +1,30 @@
+//
+//  STTwitterClock.m
+//  STTwitter
+//
+//  Created by Kirill Nepomnyaschiy on 25.12.14.
+//  Copyright (c) 2014 Nicolas Seriot. All rights reserved.
+//
+
+#import "STTwitterClock.h"
+
+@implementation STTwitterClock
+
++ (instancetype)sharedInstance {
+    static id instance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+-(BOOL)isAvailable {
+    return _timeProvider == nil ? NO : YES;
+}
+
+-(NSTimeInterval)timestamp {
+    return _timeProvider.timestamp;
+}
+
+@end

--- a/STTwitter/STTwitterOAuth.m
+++ b/STTwitter/STTwitterOAuth.m
@@ -10,6 +10,7 @@
 #import "STHTTPRequest.h"
 #import "NSString+STTwitter.h"
 #import "STHTTPRequest+STTwitter.h"
+#import "STTwitterClock.h"
 
 #include <CommonCrypto/CommonHMAC.h>
 
@@ -242,7 +243,13 @@
     
     if(_testOauthTimestamp) return _testOauthTimestamp;
     
-    NSTimeInterval timeInterval = [[NSDate date] timeIntervalSince1970];
+    NSTimeInterval timeInterval = 0;
+    
+    if ([STTwitterClock sharedInstance].isAvailable) {
+        timeInterval = [STTwitterClock sharedInstance].timestamp;
+    } else {
+        timeInterval = [[NSDate date] timeIntervalSince1970];
+    }
     
     return [NSString stringWithFormat:@"%d", (int)timeInterval];
 }

--- a/Tests/UnitTests.xcodeproj/project.pbxproj
+++ b/Tests/UnitTests.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		03E5FDFA19236FB9007BE44D /* STTwitterOSRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E5FDDE19236FB9007BE44D /* STTwitterOSRequest.m */; };
 		03E5FDFF19236FB9007BE44D /* STHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E5FDE619236FB9007BE44D /* STHTTPRequest.m */; };
 		03E5FE0019236FB9007BE44D /* STHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E5FDE619236FB9007BE44D /* STHTTPRequest.m */; };
+		AEAD49C31A4C34A900AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49C21A4C34A900AA8EC5 /* STTwitterClock.m */; };
+		AEAD49C41A4C34A900AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49C21A4C34A900AA8EC5 /* STTwitterClock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,6 +119,8 @@
 		03E5FDDF19236FB9007BE44D /* STTwitterProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterProtocol.h; sourceTree = "<group>"; };
 		03E5FDE519236FB9007BE44D /* STHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STHTTPRequest.h; sourceTree = "<group>"; };
 		03E5FDE619236FB9007BE44D /* STHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STHTTPRequest.m; sourceTree = "<group>"; };
+		AEAD49C11A4C34A900AA8EC5 /* STTwitterClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterClock.h; sourceTree = "<group>"; };
+		AEAD49C21A4C34A900AA8EC5 /* STTwitterClock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STTwitterClock.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,6 +250,8 @@
 				03E5FDD419236FB9007BE44D /* STTwitterAPI.m */,
 				03E5FDD519236FB9007BE44D /* STTwitterAppOnly.h */,
 				03E5FDD619236FB9007BE44D /* STTwitterAppOnly.m */,
+				AEAD49C11A4C34A900AA8EC5 /* STTwitterClock.h */,
+				AEAD49C21A4C34A900AA8EC5 /* STTwitterClock.m */,
 				03E5FDD719236FB9007BE44D /* STTwitterHTML.h */,
 				03E5FDD819236FB9007BE44D /* STTwitterHTML.m */,
 				03E5FDD919236FB9007BE44D /* STTwitterOAuth.h */,
@@ -365,6 +371,7 @@
 				03E5FDF819236FB9007BE44D /* STTwitterOS.m in Sources */,
 				03E5FDFA19236FB9007BE44D /* STTwitterOSRequest.m in Sources */,
 				03E5FDEC19236FB9007BE44D /* NSString+STTwitter.m in Sources */,
+				AEAD49C41A4C34A900AA8EC5 /* STTwitterClock.m in Sources */,
 				03E5FDEE19236FB9007BE44D /* STHTTPRequest+STTwitter.m in Sources */,
 				0315BC9117E0944900F226E6 /* STHTTPRequestTestResponse.m in Sources */,
 				03E5FE0019236FB9007BE44D /* STHTTPRequest.m in Sources */,
@@ -381,6 +388,7 @@
 			files = (
 				03E5FDEB19236FB9007BE44D /* NSString+STTwitter.m in Sources */,
 				03E5FDFF19236FB9007BE44D /* STHTTPRequest.m in Sources */,
+				AEAD49C31A4C34A900AA8EC5 /* STTwitterClock.m in Sources */,
 				03E5FDF319236FB9007BE44D /* STTwitterHTML.m in Sources */,
 				03E5FDEF19236FB9007BE44D /* STTwitterAPI.m in Sources */,
 				03E5FDF519236FB9007BE44D /* STTwitterOAuth.m in Sources */,
@@ -573,6 +581,7 @@
 				03E5FDC719236F92007BE44D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/demo_cli/sttwitter_cli.xcodeproj/project.pbxproj
+++ b/demo_cli/sttwitter_cli.xcodeproj/project.pbxproj
@@ -143,6 +143,14 @@
 		03C4145319150EA300370144 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C4145219150EA300370144 /* main.m */; };
 		03E5FD3E1922636C007BE44D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03C412FE1913BF7400370144 /* Foundation.framework */; };
 		03E5FD411922636C007BE44D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E5FD401922636C007BE44D /* main.m */; };
+		AEAD49B61A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49B71A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49B81A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49B91A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49BA1A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49BB1A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49BC1A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
+		AEAD49BD1A4C340100AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -271,6 +279,8 @@
 		03C4145219150EA300370144 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		03E5FD3D1922636C007BE44D /* t2rss */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = t2rss; sourceTree = BUILT_PRODUCTS_DIR; };
 		03E5FD401922636C007BE44D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AEAD49B41A4C340100AA8EC5 /* STTwitterClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterClock.h; sourceTree = "<group>"; };
+		AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STTwitterClock.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -389,6 +399,8 @@
 				0315A0F61927FC79001C6C02 /* STTwitterAPI.m */,
 				0315A0F71927FC79001C6C02 /* STTwitterAppOnly.h */,
 				0315A0F81927FC79001C6C02 /* STTwitterAppOnly.m */,
+				AEAD49B41A4C340100AA8EC5 /* STTwitterClock.h */,
+				AEAD49B51A4C340100AA8EC5 /* STTwitterClock.m */,
 				0315A0F91927FC79001C6C02 /* STTwitterHTML.h */,
 				0315A0FA1927FC79001C6C02 /* STTwitterHTML.m */,
 				0315A0FB1927FC79001C6C02 /* STTwitterOAuth.h */,
@@ -689,6 +701,7 @@
 			files = (
 				0315A15F1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11F1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49BC1A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16F1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13F1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12F1927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -710,6 +723,7 @@
 			files = (
 				0315A1601927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A1201927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49BD1A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A1701927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A1401927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A1301927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -731,6 +745,7 @@
 			files = (
 				0315A15D1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11D1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49BA1A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16D1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13D1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12D1927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -752,6 +767,7 @@
 			files = (
 				0315A1591927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A1191927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49B61A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A1691927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A1391927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A1291927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -773,6 +789,7 @@
 			files = (
 				0315A15A1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11A1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49B71A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16A1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13A1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12A1927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -794,6 +811,7 @@
 			files = (
 				0315A15B1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11B1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49B81A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16B1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13B1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12B1927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -815,6 +833,7 @@
 			files = (
 				0315A15C1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11C1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49B91A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16C1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13C1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12C1927FC79001C6C02 /* STTwitterAPI.m in Sources */,
@@ -836,6 +855,7 @@
 			files = (
 				0315A15E1927FC79001C6C02 /* BAVPlistNode.m in Sources */,
 				0315A11E1927FC79001C6C02 /* NSString+STTwitter.m in Sources */,
+				AEAD49BB1A4C340100AA8EC5 /* STTwitterClock.m in Sources */,
 				0315A16E1927FC79001C6C02 /* STHTTPRequest.m in Sources */,
 				0315A13E1927FC79001C6C02 /* STTwitterHTML.m in Sources */,
 				0315A12E1927FC79001C6C02 /* STTwitterAPI.m in Sources */,

--- a/demo_ios/STTwitterDemoIOS.xcodeproj/project.pbxproj
+++ b/demo_ios/STTwitterDemoIOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0344DB1518D9CB0E004AC0BB /* NSError+STTwitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0344DB1418D9CB0E004AC0BB /* NSError+STTwitter.m */; };
 		03ACFD3C18390F7B005CEE2A /* NSDateFormatter+STTwitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03ACFD3B18390F7B005CEE2A /* NSDateFormatter+STTwitter.m */; };
 		03D5C41419D5737400BE9642 /* WebViewVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D5C41319D5737400BE9642 /* WebViewVC.m */; };
+		AEAD49B31A4C331400AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49B21A4C331400AA8EC5 /* STTwitterClock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -77,6 +78,8 @@
 		03ACFD3B18390F7B005CEE2A /* NSDateFormatter+STTwitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+STTwitter.m"; sourceTree = "<group>"; };
 		03D5C41219D5737400BE9642 /* WebViewVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebViewVC.h; sourceTree = "<group>"; };
 		03D5C41319D5737400BE9642 /* WebViewVC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebViewVC.m; sourceTree = "<group>"; };
+		AEAD49B11A4C331400AA8EC5 /* STTwitterClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterClock.h; sourceTree = "<group>"; };
+		AEAD49B21A4C331400AA8EC5 /* STTwitterClock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STTwitterClock.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,10 +156,12 @@
 		03144B7717FB6109007812DC /* STTwitter */ = {
 			isa = PBXGroup;
 			children = (
-				03144B7817FB6109007812DC /* NSString+STTwitter.h */,
-				03144B7917FB6109007812DC /* NSString+STTwitter.m */,
 				03ACFD3A18390F7B005CEE2A /* NSDateFormatter+STTwitter.h */,
 				03ACFD3B18390F7B005CEE2A /* NSDateFormatter+STTwitter.m */,
+				0344DB1318D9CB0E004AC0BB /* NSError+STTwitter.h */,
+				0344DB1418D9CB0E004AC0BB /* NSError+STTwitter.m */,
+				03144B7817FB6109007812DC /* NSString+STTwitter.h */,
+				03144B7917FB6109007812DC /* NSString+STTwitter.m */,
 				03144B7A17FB6109007812DC /* STHTTPRequest+STTwitter.h */,
 				03144B7B17FB6109007812DC /* STHTTPRequest+STTwitter.m */,
 				03144B7C17FB6109007812DC /* STTwitter.h */,
@@ -164,6 +169,8 @@
 				03144B7E17FB6109007812DC /* STTwitterAPI.m */,
 				03144B7F17FB6109007812DC /* STTwitterAppOnly.h */,
 				03144B8017FB6109007812DC /* STTwitterAppOnly.m */,
+				AEAD49B11A4C331400AA8EC5 /* STTwitterClock.h */,
+				AEAD49B21A4C331400AA8EC5 /* STTwitterClock.m */,
 				03144B8117FB6109007812DC /* STTwitterHTML.h */,
 				03144B8217FB6109007812DC /* STTwitterHTML.m */,
 				03144B8317FB6109007812DC /* STTwitterOAuth.h */,
@@ -172,8 +179,6 @@
 				03144B8617FB6109007812DC /* STTwitterOS.m */,
 				03426AF318B947FB00CA9ABF /* STTwitterOSRequest.h */,
 				03426AF418B947FB00CA9ABF /* STTwitterOSRequest.m */,
-				0344DB1318D9CB0E004AC0BB /* NSError+STTwitter.h */,
-				0344DB1418D9CB0E004AC0BB /* NSError+STTwitter.m */,
 				03144B8717FB6109007812DC /* STTwitterProtocol.h */,
 				03144B8817FB6109007812DC /* Vendor */,
 			);
@@ -267,6 +272,7 @@
 				03144B9217FB6109007812DC /* STTwitterOAuth.m in Sources */,
 				03426AF518B947FB00CA9ABF /* STTwitterOSRequest.m in Sources */,
 				03D5C41419D5737400BE9642 /* WebViewVC.m in Sources */,
+				AEAD49B31A4C331400AA8EC5 /* STTwitterClock.m in Sources */,
 				03144B5917FB608C007812DC /* ViewController.m in Sources */,
 				03144B9517FB6109007812DC /* STHTTPRequest.m in Sources */,
 				03144B5317FB608C007812DC /* AppDelegate.m in Sources */,

--- a/demo_osx/STTwitterDemoOSX.xcodeproj/project.pbxproj
+++ b/demo_osx/STTwitterDemoOSX.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		0344DB1218D9C698004AC0BB /* NSError+STTwitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0344DB1118D9C698004AC0BB /* NSError+STTwitter.m */; };
 		039910E317F371A5005FFFC3 /* JSONSyntaxHighlight.m in Sources */ = {isa = PBXBuildFile; fileRef = 039910E217F371A5005FFFC3 /* JSONSyntaxHighlight.m */; };
 		03ACFD3918390F68005CEE2A /* NSDateFormatter+STTwitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03ACFD3818390F68005CEE2A /* NSDateFormatter+STTwitter.m */; };
+		AEAD49C01A4C347A00AA8EC5 /* STTwitterClock.m in Sources */ = {isa = PBXBuildFile; fileRef = AEAD49BF1A4C347A00AA8EC5 /* STTwitterClock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +96,8 @@
 		039910E217F371A5005FFFC3 /* JSONSyntaxHighlight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONSyntaxHighlight.m; sourceTree = "<group>"; };
 		03ACFD3718390F68005CEE2A /* NSDateFormatter+STTwitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+STTwitter.h"; sourceTree = "<group>"; };
 		03ACFD3818390F68005CEE2A /* NSDateFormatter+STTwitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+STTwitter.m"; sourceTree = "<group>"; };
+		AEAD49BE1A4C347A00AA8EC5 /* STTwitterClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterClock.h; sourceTree = "<group>"; };
+		AEAD49BF1A4C347A00AA8EC5 /* STTwitterClock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STTwitterClock.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,10 +194,12 @@
 		03191E8A17BF704C0001C06D /* STTwitter */ = {
 			isa = PBXGroup;
 			children = (
-				03191E8B17BF704C0001C06D /* NSString+STTwitter.h */,
-				03191E8C17BF704C0001C06D /* NSString+STTwitter.m */,
 				03ACFD3718390F68005CEE2A /* NSDateFormatter+STTwitter.h */,
 				03ACFD3818390F68005CEE2A /* NSDateFormatter+STTwitter.m */,
+				0344DB1018D9C698004AC0BB /* NSError+STTwitter.h */,
+				0344DB1118D9C698004AC0BB /* NSError+STTwitter.m */,
+				03191E8B17BF704C0001C06D /* NSString+STTwitter.h */,
+				03191E8C17BF704C0001C06D /* NSString+STTwitter.m */,
 				03191E8D17BF704C0001C06D /* STHTTPRequest+STTwitter.h */,
 				03191E8E17BF704C0001C06D /* STHTTPRequest+STTwitter.m */,
 				03191E8F17BF704C0001C06D /* STTwitter.h */,
@@ -202,6 +207,8 @@
 				03191E9117BF704C0001C06D /* STTwitterAPI.m */,
 				03191E9217BF704C0001C06D /* STTwitterAppOnly.h */,
 				03191E9317BF704C0001C06D /* STTwitterAppOnly.m */,
+				AEAD49BE1A4C347A00AA8EC5 /* STTwitterClock.h */,
+				AEAD49BF1A4C347A00AA8EC5 /* STTwitterClock.m */,
 				03191E9417BF704C0001C06D /* STTwitterHTML.h */,
 				03191E9517BF704C0001C06D /* STTwitterHTML.m */,
 				03191E9617BF704C0001C06D /* STTwitterOAuth.h */,
@@ -210,8 +217,6 @@
 				03191E9917BF704C0001C06D /* STTwitterOS.m */,
 				03426AED18B725B200CA9ABF /* STTwitterOSRequest.h */,
 				03426AEE18B725B200CA9ABF /* STTwitterOSRequest.m */,
-				0344DB1018D9C698004AC0BB /* NSError+STTwitter.h */,
-				0344DB1118D9C698004AC0BB /* NSError+STTwitter.m */,
 				03191E9A17BF704C0001C06D /* STTwitterProtocol.h */,
 				03191E9B17BF704C0001C06D /* Vendor */,
 			);
@@ -306,6 +311,7 @@
 				03191E6A17BF700A0001C06D /* AppDelegate.m in Sources */,
 				039910E317F371A5005FFFC3 /* JSONSyntaxHighlight.m in Sources */,
 				03191E9E17BF704C0001C06D /* NSString+STTwitter.m in Sources */,
+				AEAD49C01A4C347A00AA8EC5 /* STTwitterClock.m in Sources */,
 				03191EA017BF704C0001C06D /* STHTTPRequest+STTwitter.m in Sources */,
 				03144B9817FC3404007812DC /* BAVPlistNode.m in Sources */,
 				03191EA217BF704C0001C06D /* STTwitterAPI.m in Sources */,


### PR DESCRIPTION
I admit that it's probably not the best implementation of this feature but I think It's pretty crucial to have any. Please let me know if it can be done in other way.