### PR TITLE
Use the new value of `e` in the final errorBlock.

### DIFF
--- a/STTwitter/STHTTPRequest+STTwitter.m
+++ b/STTwitter/STHTTPRequest+STTwitter.m
@@ -100,7 +100,7 @@
         //        BOOL isCancellationError = [[error domain] isEqualToString:@"STHTTPRequest"] && ([error code] == kSTHTTPRequestCancellationError);
         //        if(isCancellationError) return;
         
-        errorBlock(wr.requestHeaders, wr.responseHeaders, error);
+        errorBlock(wr.requestHeaders, wr.responseHeaders, e);
     };
     
     return r;


### PR DESCRIPTION
There is an earlier call to errorBlock that consumers `error`, but is gated by an `if (error)` check. `error` doesn't change in the meantime, so the second call doesn't make sense. On top of that, the second value of `e` was going unused, causing a static analysis issue. It seems like the final errorBlock intends to pass `e`, as its new value packages the responseString, which is the most likely source of an explanation for why the response triggered the outer errorBlock instead of its completionBlock.