### PR TITLE
Fixed a getFavoritesListWithUserID parameter name

### DIFF
--- a/STTwitter/STTwitterAPI.h
+++ b/STTwitter/STTwitterAPI.h
@@ -1250,7 +1250,7 @@ includeMessagesFromFollowedAccounts:(NSNumber *)includeMessagesFromFollowedAccou
  */
 
 - (void)getFavoritesListWithUserID:(NSString *)userID
-                        screenName:(NSString *)screenName
+                      orScreenName:(NSString *)screenName
                              count:(NSString *)count
                            sinceID:(NSString *)sinceID
                              maxID:(NSString *)maxID


### PR DESCRIPTION
Don’t require both screenName and userID for getting favorites, naming more consistent with other methods