### PR TITLE
Declares enums to be external to prevent duplicate symbols error

### DIFF
--- a/STTwitter/STTwitterAPI.h
+++ b/STTwitter/STTwitterAPI.h
@@ -23,8 +23,8 @@
 #import "STTwitterStreamParser.h"
 #import "STTwitterRequestProtocol.h"
 
-NS_ENUM(NSUInteger, STTwitterAPIErrorCode) {
-    STTwitterAPICannotPostEmptyStatus,
+extern NS_ENUM(NSUInteger, STTwitterAPIErrorCode) {
+    STTwitterAPICannotPostEmptyStatus = 0,
     STTwitterAPIMediaDataIsEmpty,
     STTwitterAPIEmptyStream
 };

--- a/STTwitter/STTwitterAppOnly.h
+++ b/STTwitter/STTwitterAppOnly.h
@@ -15,8 +15,8 @@
 #   define STLog(...)
 #endif
 
-NS_ENUM(NSUInteger, STTwitterAppOnlyErrorCode) {
-    STTwitterAppOnlyCannotFindBearerTokenToBeInvalidated,
+extern NS_ENUM(NSUInteger, STTwitterAppOnlyErrorCode) {
+    STTwitterAppOnlyCannotFindBearerTokenToBeInvalidated = 0,
     STTwitterAppOnlyCannotFindJSONInResponse,
     STTwitterAppOnlyCannotFindBearerTokenInResponse
 };

--- a/STTwitter/STTwitterHTML.h
+++ b/STTwitter/STTwitterHTML.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ENUM(NSUInteger, STTwitterHTMLErrorCode) {
-    STTwitterHTMLCannotPostWithoutCredentials
+extern NS_ENUM(NSUInteger, STTwitterHTMLErrorCode) {
+    STTwitterHTMLCannotPostWithoutCredentials = 0
 };
 
 @interface STTwitterHTML : NSObject

--- a/STTwitter/STTwitterOAuth.h
+++ b/STTwitter/STTwitterOAuth.h
@@ -20,8 +20,8 @@
  ...
  */
 
-NS_ENUM(NSUInteger, STTwitterOAuthErrorCode) {
-    STTwitterOAuthCannotPostAccessTokenRequestWithoutPIN,
+extern NS_ENUM(NSUInteger, STTwitterOAuthErrorCode) {
+    STTwitterOAuthCannotPostAccessTokenRequestWithoutPIN = 0,
     STTwitterOAuthBadCredentialsOrConsumerTokensNotXAuthEnabled
 };
 

--- a/STTwitter/STTwitterOS.h
+++ b/STTwitter/STTwitterOS.h
@@ -9,8 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "STTwitterProtocol.h"
 
-NS_ENUM(NSUInteger, STTwitterOSErrorCode) {
-    STTwitterOSSystemCannotAccessTwitter,
+extern NS_ENUM(NSUInteger, STTwitterOSErrorCode) {
+    STTwitterOSSystemCannotAccessTwitter = 0,
     STTwitterOSCannotFindTwitterAccount,
     STTwitterOSUserDeniedAccessToTheirAccounts,
     STTwitterOSNoTwitterAccountIsAvailable


### PR DESCRIPTION
Integrating STTwitter into my project broke the build at the linking phase with a "duplicate symbols" error. I traced the problem to the NS_ENUMS in the headers. Adding an extern declaration fixed the problem.