### PR TITLE
It is able to define behavior when detected AccountStore did change.

### DIFF
--- a/STTwitter/STTwitterAPI.h
+++ b/STTwitter/STTwitterAPI.h
@@ -22,6 +22,7 @@
 #import <Foundation/Foundation.h>
 #import "STTwitterStreamParser.h"
 #import "STTwitterRequestProtocol.h"
+#import "STTwitterAPIDelegate.h"
 
 extern NS_ENUM(NSUInteger, STTwitterAPIErrorCode) {
     STTwitterAPICannotPostEmptyStatus = 0,
@@ -48,6 +49,8 @@ extern NSString *kBaseURLStringSiteStream_1_1;
 
 + (instancetype)twitterAPIOSWithAccount:(ACAccount *)account;
 + (instancetype)twitterAPIOSWithFirstAccount;
++ (instancetype)twitterAPIOSWithAccount:(ACAccount *)account withDelegate:(id<STTwitterAPIDelegate>)delegate;
++ (instancetype)twitterAPIOSWithFirstAccountWithDelegate:(id<STTwitterAPIDelegate>)delegate;
 
 + (instancetype)twitterAPIWithOAuthConsumerName:(NSString *)consumerName // purely informational, can be anything
                                     consumerKey:(NSString *)consumerKey
@@ -148,6 +151,8 @@ authenticateInsteadOfAuthorize:(BOOL)authenticateInsteadOfAuthorize // use NO if
 @property (nonatomic, readonly) NSString *oauthAccessToken;
 @property (nonatomic, readonly) NSString *oauthAccessTokenSecret;
 @property (nonatomic, readonly) NSString *bearerToken;
+
+@property (nonatomic, weak) id<STTwitterAPIDelegate> delegate;
 
 - (NSDictionary *)OAuthEchoHeadersToVerifyCredentials;
 

--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -43,7 +43,14 @@ static NSDateFormatter *dateFormatter = nil;
         typeof(self) strongSelf = weakSelf;
         
         if([strongSelf.oauth isKindOfClass:[STTwitterOS class]]) {
-            strongSelf.oauth = nil;
+			
+			BOOL shouldReset = YES;
+			
+			if ([self.delegate respondsToSelector:@selector(twitterAPI:shouldDisableCurrentOAuth:accountStore:)]) {
+				shouldReset = [self.delegate twitterAPI:self shouldDisableCurrentOAuth:(STTwitterOS*)self.oauth accountStore:note.object];
+			}
+			
+			if (shouldReset) strongSelf.oauth = nil;
         }
     }];
     
@@ -59,13 +66,23 @@ static NSDateFormatter *dateFormatter = nil;
 }
 
 + (instancetype)twitterAPIOSWithAccount:(ACAccount *)account {
+	return [self twitterAPIOSWithAccount:account withDelegate:nil];
+}
+
++ (instancetype)twitterAPIOSWithFirstAccount {
+	return [self twitterAPIOSWithFirstAccountWithDelegate:nil];
+}
+
++ (instancetype)twitterAPIOSWithAccount:(ACAccount *)account withDelegate:(id<STTwitterAPIDelegate>)delegate {
     STTwitterAPI *twitter = [[STTwitterAPI alloc] init];
+	twitter.delegate = delegate;
     twitter.oauth = [STTwitterOS twitterAPIOSWithAccount:account];
     return twitter;
 }
 
-+ (instancetype)twitterAPIOSWithFirstAccount {
++ (instancetype)twitterAPIOSWithFirstAccountWithDelegate:(id<STTwitterAPIDelegate>)delegate {
     STTwitterAPI *twitter = [[STTwitterAPI alloc] init];
+	twitter.delegate = delegate;
     twitter.oauth = [STTwitterOS twitterAPIOSWithAccount:nil];
     return twitter;
 }

--- a/STTwitter/STTwitterAPIDelegate.h
+++ b/STTwitter/STTwitterAPIDelegate.h
@@ -1,0 +1,25 @@
+//
+//  STTwitterAPIDelegate.h
+//  STTwitterDemoOSX
+//
+//  Created by Tomohiro Kumagai on H27/08/15.
+//  Copyright © 平成27年 Nicolas Seriot. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "STTwitterAPI.h"
+
+@class STTwitterAPI;
+@class STTwitterOS;
+@class ACAccountStore;
+
+@protocol STTwitterAPIDelegate <NSObject>
+
+@optional
+
+/// This method called when received ACAccountStoreDidChangeNotification using authentication supplied by OS.
+/// You return whether the current oauth shuld be disable.
+/// If you don't implement the delegate method, It is assumed that it returns YES.
+- (BOOL)twitterAPI:(STTwitterAPI*)api shouldDisableCurrentOAuth:(STTwitterOS*)oauth accountStore:(ACAccountStore*)accountStore;
+
+@end

--- a/demo_osx/STTwitterDemoOSX.xcodeproj/project.pbxproj
+++ b/demo_osx/STTwitterDemoOSX.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		039910E217F371A5005FFFC3 /* JSONSyntaxHighlight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONSyntaxHighlight.m; sourceTree = "<group>"; };
 		03ACFD3718390F68005CEE2A /* NSDateFormatter+STTwitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+STTwitter.h"; sourceTree = "<group>"; };
 		03ACFD3818390F68005CEE2A /* NSDateFormatter+STTwitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+STTwitter.m"; sourceTree = "<group>"; };
+		B12BD9281B7F7E8C00FD9632 /* STTwitterAPIDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STTwitterAPIDelegate.h; sourceTree = "<group>"; };
 		B894413A1ABF571F00FC5D6F /* STTwitterStreamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STTwitterStreamParser.h; sourceTree = "<group>"; };
 		B894413B1ABF571F00FC5D6F /* STTwitterStreamParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = STTwitterStreamParser.m; sourceTree = "<group>"; };
 		B8BDD51C1AC12807003672C3 /* STTwitterRequestProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STTwitterRequestProtocol.h; sourceTree = "<group>"; };
@@ -204,6 +205,7 @@
 				03191E8F17BF704C0001C06D /* STTwitter.h */,
 				03191E9017BF704C0001C06D /* STTwitterAPI.h */,
 				03191E9117BF704C0001C06D /* STTwitterAPI.m */,
+				B12BD9281B7F7E8C00FD9632 /* STTwitterAPIDelegate.h */,
 				03191E9217BF704C0001C06D /* STTwitterAppOnly.h */,
 				03191E9317BF704C0001C06D /* STTwitterAppOnly.m */,
 				03191E9417BF704C0001C06D /* STTwitterHTML.h */,


### PR DESCRIPTION
In relation to Issue #213

For example, when received an ACAccountStoreDidChangeNotification, delegate method `twitterAPI:shouldDisableCurrentOAuth:accountStore:` will be called.

If the method returns YES, nil will set to STTwitterAPI’s oauth property. Otherwise keep the value. If the delegate method is not implemented, it considered that it return YES. In other words, it is conventional behavior. 

What about this modification.