### PR TITLE
Use first OS account if no account specified

### DIFF
--- a/STTwitter/STTwitterOS.m
+++ b/STTwitter/STTwitterOS.m
@@ -195,7 +195,7 @@ const NSString *STTwitterOSInvalidatedAccount = @"STTwitterOSInvalidatedAccount"
                     return;
                 }
                 
-                if([account.username isEqualToString:previouslyStoredUsername]) {
+                if(formerAccount == nil || [account.username isEqualToString:previouslyStoredUsername]) {
                     strongSelf.account = account;
                     *stop = YES;
                     accountFound = YES;


### PR DESCRIPTION
Before commit bb8306560b4dd1025480f4d8a164b0914c3cb287, calls to `+twitterAPIOSWithFirstAccount` would use the first account found that had an identifier, but after that change no account will be used. No account will pass `[account.username isEqualToString:previouslyStoredUsername]` where `previouslyStoredUsername` is nil, and calls will result in an error of "Twitter account is invalid: (null)".