### PR TITLE
Fix include_email query param value for account/verify_credentials REST API endpoint

### DIFF
--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -2258,7 +2258,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
     if(includeEntities) md[@"include_entities"] = [includeEntities boolValue] ? @"1" : @"0";
     if(skipStatus) md[@"skip_status"] = [skipStatus boolValue] ? @"1" : @"0";
-    if(includeEmail) md[@"include_email"] = [includeEmail boolValue] ? @"1" : @"0";
+    if(includeEmail) md[@"include_email"] = [includeEmail boolValue] ? @"true" : @"false";
     
     return [self getAPIResource:@"account/verify_credentials.json" parameters:md successBlock:^(NSDictionary *rateLimits, id response) {
         successBlock(response);


### PR DESCRIPTION
Only 'true' and 'false' values are acceptable for it.

I've tested STTwitter on an application that is whitelisted by Twitter to access user's email address when calling [GET account/verify_credentials](https://dev.twitter.com/rest/reference/get/account/verify_credentials) REST API endpoint.

When calling getAccountVerifyCredentialsWithIncludeEntites method with includeEmail set to 1 , it adds the include_email parameter with the value of "1" to the query string parameters sent to the verify_credentials endpoint. (e.g. `https://api.twitter.com/1.1/account/verify_credentials.json?include_email=1`), however no email key is returned in the JSON response.

After further debugging I've found that setting the include_email parameter to the value of "1" is the problem. 
According to the docs on the verify_credentials endpoint, the possible values for it are "true" and "false":
```
include_email optional

Use of this parameter requires whitelisting.

When set to true email will be returned in the user objects as a string. If the user does not have an email address on their account, or if the email address is un-verified, null will be returned.

Example Values: true
```

Changing the values for the include_email parameter sent to the verify_credentials endpoint to "true" (e.g. `https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true`), correctly returns the email parameter in the response.

I think this is either an inconsistency in the Twitter API or a deliberate decision, because other endpoint parameters accept either true, t or 1 values. (e.g. skip_status) 
```
skip_status optional

When set to either true, t or 1 statuses will not be included in the returned user object.

Example Values: true
```

or include_entities, even though the include_entities documentation only says it accepts "true" or "false"
```
include_entities optional

The entities node will not be included when set to false.

Example Values: false
```
However using include_entities with a value of "1" returns the entities in the response, even though the docs don't mention that it accepts anything other than "true" or "false" for its value.

To fix the problem with the include_email parameter I propose to change the values that STTwitter sends to the verify_credentials endpoint for it.