### PR TITLE
Update GET/trends/place endpoint for hashtag exclusion

### DIFF
--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -4108,7 +4108,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
     
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
     md[@"id"] = WOEID;
-    if(excludeHashtags) md[@"exclude"] = [excludeHashtags boolValue] ? @"1" : @"0";
+    if(excludeHashtags) md[@"exclude"] = [excludeHashtags boolValue] ? @"hashtags" : @"0";
     
     return [self getAPIResource:@"trends/place.json" parameters:md successBlock:^(NSDictionary *rateLimits, id response) {
         


### PR DESCRIPTION
Hashtag exclusion was not working for this endpoint.  

I updated this to mesh with the latest [Twitter API docs for this endpoint](https://dev.twitter.com/rest/reference/get/trends/place):
"Setting this equal to hashtags will remove all hashtags from the trends list."
