### PR TITLE
fix don't work stringify_friend_ids parameter

### DIFF
--- a/STTwitter/STTwitterAPI.h
+++ b/STTwitter/STTwitterAPI.h
@@ -712,7 +712,7 @@ authenticateInsteadOfAuthorize:(BOOL)authenticateInsteadOfAuthorize // use NO if
 
 - (NSObject<STTwitterRequestProtocol> *)getDirectMessagesShowWithID:(NSString *)messageID
                                                            fullText:(NSNumber *)fullText
-                                                       successBlock:(void(^)(NSArray *statuses))successBlock
+                                                       successBlock:(void(^)(NSDictionary *message))successBlock
                                                          errorBlock:(void(^)(NSError *error))errorBlock;
 
 /*

--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -1817,7 +1817,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
 
 - (NSObject<STTwitterRequestProtocol> *)getDirectMessagesShowWithID:(NSString *)messageID
                                                            fullText:(NSNumber *)fullText
-                                                       successBlock:(void(^)(NSArray *messages))successBlock
+                                                       successBlock:(void(^)(NSDictionary *message))successBlock
                                                          errorBlock:(void(^)(NSError *error))errorBlock {
     
     NSMutableDictionary *md = [NSMutableDictionary dictionary];

--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -2886,7 +2886,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
                                                         errorBlock:(void(^)(NSError *error))errorBlock {
     
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
-    
+    md[@"stringify_ids"] = @"1";
     if(cursor) md[@"cursor"] = cursor;
     
     return [self getAPIResource:@"mutes/users/ids.json" parameters:md successBlock:^(NSDictionary *rateLimits, id response) {

--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -1618,7 +1618,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
                                                         errorBlock:(void(^)(NSError *error))errorBlock {
     
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
-    md[@"stringify_friend_ids"] = @"1";
+    md[@"stringify_friend_ids"] = @"true";
     md[@"delimited"] = @"length";
     
     if(stallWarnings) md[@"stall_warnings"] = [stallWarnings boolValue] ? @"1" : @"0";
@@ -1713,7 +1713,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
                                                      errorBlock:(void(^)(NSError *error))errorBlock {
     
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
-    md[@"stringify_friend_ids"] = @"1";
+    md[@"stringify_friend_ids"] = @"true";
     if(delimited) md[@"delimited"] = [delimited boolValue] ? @"1" : @"0";
     if(stallWarnings) md[@"stall_warnings"] = [stallWarnings boolValue] ? @"1" : @"0";
     if(restrictToUserMessages) md[@"with"] = @"user"; // default is 'followings'


### PR DESCRIPTION
I tried User Stream API.

I got numeric friend ids. 
But I expect stringify friend ids.

I tried changing stringify_friend_ids parameter, @"1" to @"true".

I got a result that is I expected.
## When `md[@"stringify_friend_ids"] = @"1";`

I got numeric friend ids. 

![image](https://cloud.githubusercontent.com/assets/537587/19678330/4502a8e6-9ad8-11e6-9f46-7274219956ec.png)
## `md[@"stringify_friend_ids"] = @"true";`

I got stringify friend ids. 👍 

![image](https://cloud.githubusercontent.com/assets/537587/19678421/a88da0aa-9ad8-11e6-93c3-54cc27196d4b.png)


---

At the same time other bugs...