### PR TITLE
Use profile_image_url_https for ATS

### DIFF
--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -632,7 +632,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
                               
                               if(strongSelf == nil) return;
                               
-                              NSString *imageURLString = [response objectForKey:@"profile_image_url"];
+                              NSString *imageURLString = [response objectForKey:@"profile_image_url_https"];
                               
                               STHTTPRequest *r = [STHTTPRequest requestWithURLString:imageURLString];
                               r.sharedContainerIdentifier = [[NSUserDefaults standardUserDefaults] valueForKey:@"STTwitterSharedContainerIdentifier"];


### PR DESCRIPTION
Use https instead of http url in
'-profileImageFor:successBlock:errorBlock:' to comply with Apple's App
Transport Security.