### PR TITLE
add parameter  tweet_mode = extended to getStatusesShowID

### DIFF
--- a/STTwitter/STTwitterAPI.m
+++ b/STTwitter/STTwitterAPI.m
@@ -931,6 +931,7 @@ authenticateInsteadOfAuthorize:authenticateInsteadOfAuthorize
     NSMutableDictionary *md = [NSMutableDictionary dictionary];
     
     md[@"id"] = statusID;
+    md[@"tweet_mode"] = @"extended";
     if(trimUser) md[@"trim_user"] = [trimUser boolValue] ? @"1" : @"0";
     if(includeMyRetweet) md[@"include_my_retweet"] = [includeMyRetweet boolValue] ? @"1" : @"0";
     if(includeEntities) md[@"include_entities"] = [includeEntities boolValue] ? @"1" : @"0";


### PR DESCRIPTION
Some tweets are truncated like the retweeted ones when getting the status using getStatusesShowID
like this https://twitter.com/skynewsarabia/status/803789534483755008
tweet_mode = extended will show all the tweet details