### PR TITLE
Fix build warning "Sending 'const NSString *' to parameter of type 'N…

### DIFF
--- a/STTwitter/STTwitterOS.h
+++ b/STTwitter/STTwitterOS.h
@@ -19,7 +19,7 @@ extern NS_ENUM(NSUInteger, STTwitterOSErrorCode) {
 
 @class ACAccount;
 
-extern const NSString *STTwitterOSInvalidatedAccount;
+extern NSString * const STTwitterOSInvalidatedAccount;
 
 @interface STTwitterOS : NSObject <STTwitterProtocol>
 

--- a/STTwitter/STTwitterOS.m
+++ b/STTwitter/STTwitterOS.m
@@ -16,7 +16,7 @@
 #import <Twitter/Twitter.h> // iOS 5
 #endif
 
-const NSString *STTwitterOSInvalidatedAccount = @"STTwitterOSInvalidatedAccount";
+NSString * const STTwitterOSInvalidatedAccount = @"STTwitterOSInvalidatedAccount";
 
 @interface ACAccount (STTwitterOS)
 - (NSString *)st_userID; // private API


### PR DESCRIPTION
…SErrorUserInfoKey _Nonnull' (aka 'NSString *') discards qualifiers".

The pointer should be a const, not the opaque struct.